### PR TITLE
feat: remove the two dot-separated restriction

### DIFF
--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -212,10 +212,10 @@ func extractVariablesFromString(s, prefix string) ([]string, bool, string) {
 			// Invalid Examples:
 			//  - <prefix>.foo.bar.baz....
 			if j == 0 && strings.Contains(val, ".") {
-				if len(strings.Split(val, ".")) > 2 {
-					errString = fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, s, prefix)
-					return vars, true, errString
-				}
+				// if len(strings.Split(val, ".")) > 2 {
+				// 	errString = fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, s, prefix)
+				// 	return vars, true, errString
+				// }
 				vars[i] = strings.SplitN(val, ".", 2)[0]
 				break
 			}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package substitution_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -167,17 +166,17 @@ func TestValidateVariablePs(t *testing.T) {
 			vars:   sets.NewString("foo.bar.baz"),
 		},
 		expectedError: nil,
-	}, {
-		name: "invalid variable with only dots referencing parameters",
-		args: args{
-			input:  "--flag=$(params.foo.bar.baz)",
-			prefix: "params",
-			vars:   sets.NewString("foo.bar.baz"),
-		},
-		expectedError: &apis.FieldError{
-			Message: fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, "--flag=$(params.foo.bar.baz)", "params"),
-			Paths:   []string{""},
-		},
+		// }, {
+		// 	name: "invalid variable with only dots referencing parameters",
+		// 	args: args{
+		// 		input:  "--flag=$(params.foo.bar.baz)",
+		// 		prefix: "params",
+		// 		vars:   sets.NewString("foo.bar.baz"),
+		// 	},
+		// 	expectedError: &apis.FieldError{
+		// 		Message: fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, "--flag=$(params.foo.bar.baz)", "params"),
+		// 		Paths:   []string{""},
+		// 	},
 	}, {
 		name: "valid variable with dots referencing resources",
 		args: args{
@@ -186,17 +185,17 @@ func TestValidateVariablePs(t *testing.T) {
 			vars:   sets.NewString("foo"),
 		},
 		expectedError: nil,
-	}, {
-		name: "invalid variable with dots referencing resources",
-		args: args{
-			input:  "--flag=$(resources.inputs.foo.bar.baz)",
-			prefix: "resources.(?:inputs|outputs)",
-			vars:   sets.NewString("foo.bar"),
-		},
-		expectedError: &apis.FieldError{
-			Message: fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, "--flag=$(resources.inputs.foo.bar.baz)", "resources.(?:inputs|outputs)"),
-			Paths:   []string{""},
-		},
+		// }, {
+		// 	name: "invalid variable with dots referencing resources",
+		// 	args: args{
+		// 		input:  "--flag=$(resources.inputs.foo.bar.baz)",
+		// 		prefix: "resources.(?:inputs|outputs)",
+		// 		vars:   sets.NewString("foo.bar"),
+		// 	},
+		// 	expectedError: &apis.FieldError{
+		// 		Message: fmt.Sprintf(`Invalid referencing of parameters in "%s"! Only two dot-separated components after the prefix "%s" are allowed.`, "--flag=$(resources.inputs.foo.bar.baz)", "resources.(?:inputs|outputs)"),
+		// 		Paths:   []string{""},
+		// 	},
 	}, {
 		name: "valid variable contains diffetent chars",
 		args: args{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* feat: remove the two dot-separated restriction
<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
