### PR TITLE
Fix the issue with empty array replacement

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -202,7 +202,11 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 	}, {
 		name: "empty array replacement without extra elements",
 		args: args{
-			input:             v1beta1.NewArrayOrString("$(arraykey)"),
+			// input:             v1beta1.NewArrayOrString("$(arraykey)"),
+			input: &v1beta1.ArrayOrString{
+				Type:     v1beta1.ParamTypeArray,
+				ArrayVal: []string{"$(arraykey)"},
+			},
 			arrayReplacements: map[string][]string{"arraykey": {}},
 		},
 		expectedOutput: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{}},


### PR DESCRIPTION
cherry-pick commit 95337e95086120ede07fcc98c3c21758cde2390b merged by https://github.com/tektoncd/pipeline/pull/5095  in release-0.37.x

Prior to this change, if there is only one element in an array that is
a reference to an empty array, the original array becomes nil after
replacement, but it should be an empty array instead of nil.

Fixes tektoncd#5149

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

``` release-note
After the replacement with an empty array, the original array will be empty.

Example:
---
params:
  - name: myarray
     value: "$(params.anEmptyArray[*])"
```
