### PR TITLE
fix pipelinerun hang on Unknown status when duplicated params defined…

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -237,7 +237,13 @@ func ArrayReference(a string) string {
 }
 
 func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix string, paramNames sets.String, arrayParamNames sets.String) (errs *apis.FieldError) {
-	for _, param := range params {
+	taskParamNames := sets.NewString()
+
+	for i, param := range params {
+		if taskParamNames.Has(param.Name) {
+			errs = errs.Also(apis.ErrMultipleOneOf("name").ViaIndex(i))
+		}
+
 		if param.Value.Type == ParamTypeString {
 			errs = errs.Also(validateStringVariable(param.Value.StringVal, prefix, paramNames, arrayParamNames).ViaFieldKey("params", param.Name))
 		} else {
@@ -245,6 +251,7 @@ func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix 
 				errs = errs.Also(validateArrayVariable(arrayElement, prefix, paramNames, arrayParamNames).ViaFieldIndex("value", idx).ViaFieldKey("params", param.Name))
 			}
 		}
+		taskParamNames.Insert(param.Name)
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1611,6 +1611,21 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			Message: `non-existent variable in "$(params.does-not-exist)"`,
 			Paths:   []string{"[0].matrix[b-param].value[0]"},
 		},
+	},{
+		name: "invalid task use duplicate parameters",
+		tasks: []PipelineTask{{
+		Name:    "foo-task",
+		TaskRef: &TaskRef{Name: "foo-task"},
+		Params: []Param{{
+		Name: "duplicate-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "val1"},
+	}, {
+		Name: "duplicate-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "val2"},
+	}},
+	}},
+		expectedError: apis.FieldError{
+		Message: `expected exactly one, got both`,
+		Paths:   []string{"[0][1].name"},
+	},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION


Signed-off-by: jtcheng <jtcheng@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fix pipelinerun hang on Unknown status when duplicated params defined in pipelineruntask

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes


``` release-note
bug fix: fix pipelinerun hang on Unknown status when duplicated params defined in pipelineruntask
```
