### PR TITLE
fix: avoid breaking changes

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -360,7 +360,8 @@ func ApplyTaskResultsToPipelineResults(
 					stringReplacements[variable] = *resultValue
 				} else {
 					// referred result name is not existent
-					invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
+					// TODO(qingliu): for compatibility, no error need returned here.
+					// invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 					validPipelineResult = false
 				}
 			// For object type result: tasks.<taskName>.results.<objectResultName>.<individualAttribute>

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -3168,7 +3169,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			"pt1": {},
 		},
 		expectedResults: nil,
-		expectedError:   fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError:   nil,
 	}, {
 		description: "invalid-taskrun-name-no-returned-result",
 		results: []v1beta1.PipelineResult{{
@@ -3195,7 +3196,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			}},
 		},
 		expectedResults: nil,
-		expectedError:   fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError:   nil,
 	}, {
 		description: "unsuccessful-taskrun-no-returned-result",
 		results: []v1beta1.PipelineResult{{
@@ -3223,7 +3224,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			Name:  "bar",
 			Value: *v1beta1.NewStructuredValues("rae"),
 		}},
-		expectedError: fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError: nil,
 	}, {
 		description: "multiple-results-multiple-successful-tasks ",
 		results: []v1beta1.PipelineResult{{
@@ -3276,7 +3277,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			}},
 		},
 		expectedResults: nil,
-		expectedError:   fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError:   nil,
 	}, {
 		description: "right-customtask-name-wrong-result-name-no-returned-result",
 		results: []v1beta1.PipelineResult{{
@@ -3290,7 +3291,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			}},
 		},
 		expectedResults: nil,
-		expectedError:   fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError:   nil,
 	}, {
 		description: "unsuccessful-run-no-returned-result",
 		results: []v1beta1.PipelineResult{{
@@ -3301,7 +3302,7 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			"customtask": {},
 		},
 		expectedResults: nil,
-		expectedError:   fmt.Errorf("invalid pipelineresults [foo], the referred results don't exist"),
+		expectedError:   nil,
 	}, {
 		description: "wrong-result-reference-expression",
 		results: []v1beta1.PipelineResult{{
@@ -3350,6 +3351,9 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			received, err := ApplyTaskResultsToPipelineResults(tc.results, tc.taskResults, tc.runResults)
 			if tc.expectedError != nil {
+				if err == nil {
+					err = errors.New("")
+				}
 				if d := cmp.Diff(tc.expectedError.Error(), err.Error()); d != "" {
 					t.Errorf("ApplyTaskResultsToPipelineResults() errors diff %s", diff.PrintWantGot(d))
 				}


### PR DESCRIPTION
* referred result name is not existent, ignore this error.
* does not change the type of the result

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
