### PR TITLE
chore: adjust ko base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,5 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot
+defaultBaseImage: build-harbor.alauda.cn/ops/distroless-static-nonroot:20220806
 baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: ghcr.io/distroless/git
+  github.com/tektoncd/pipeline/cmd/git-init: build-harbor.alauda.cn/3rdparty/cgr.dev/chainguard/git:latest-20221129


### PR DESCRIPTION
Use the Docker v2.2 format for images, not the OCI format.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* chore: adjust ko base image
