### PR TITLE
feat: copy annotations from resolved resource to the runtime object

### DIFF
--- a/pkg/remote/resolution/resolver.go
+++ b/pkg/remote/resolution/resolver.go
@@ -24,7 +24,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	remoteresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/kmap"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -80,6 +82,15 @@ func (resolver *Resolver) Get(ctx context.Context, _, _ string) (runtime.Object,
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
 	if err != nil {
 		return nil, &ErrorInvalidRuntimeObject{original: err}
+	}
+
+	// Copy annotations from the resolved resource to the runtime object.
+	if new, ok := obj.(metav1.Object); ok {
+		new.SetAnnotations(kmap.Union(resolved.Annotations(), new.GetAnnotations()))
+		if len(new.GetAnnotations()) == 0 {
+			new.SetAnnotations(nil)
+		}
+		obj = new.(runtime.Object)
 	}
 	return obj, nil
 }

--- a/pkg/remote/resolution/resolver_test.go
+++ b/pkg/remote/resolution/resolver_test.go
@@ -34,6 +34,8 @@ kind: Pipeline
 apiVersion: tekton.dev/v1beta1
 metadata:
   name: foo
+  annotations:
+    foo: bar
 spec:
   tasks:
   - name: task1
@@ -69,8 +71,13 @@ func TestGet_Successful(t *testing.T) {
 			ResolvedResource: resolved,
 		}
 		resolver := NewResolver(requester, owner, "git", "", "", nil)
-		if _, err := resolver.Get(ctx, "foo", "bar"); err != nil {
+		if obj, err := resolver.Get(ctx, "foo", "bar"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		} else {
+			annotations := obj.(metav1.Object).GetAnnotations()
+			if annotations["foo"] != "bar" {
+				t.Fatalf("expected annotations to be set")
+			}
 		}
 
 	}


### PR DESCRIPTION
This annotations has the source information of the ResolutionRequest.
It will be synchronized to taskRun and pipelineRun, easy to debug in the future.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

NONE