### PR TITLE
chore: replace git-init base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,4 +2,4 @@ defaultBaseImage: build-harbor.alauda.cn/ops/distroless-static-nonroot:20220806
 baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: build-harbor.alauda.cn/3rdparty/cgr.dev/chainguard/git:latest-20221129
+  github.com/tektoncd/pipeline/cmd/git-init: build-harbor.alauda.cn/3rdparty/cgr.dev/chainguard/git:latest-glibc-20230317


### PR DESCRIPTION
Use a glibc-based image to avoid DNS resolver bugs. Ref: https://github.com/kubernetes/kubernetes/issues/64924

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")
