### PR TITLE
modify taskRun status step startedAt

### DIFF
--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -108,7 +108,7 @@ func TestSetTaskRunStatusBasedOnStepStatus(t *testing.T) {
 	}
 }
 
-func TestModifyTaskRunStatusTaskStartTime(t *testing.T) {
+func TestModifyTaskRunStatusStepStartTime(t *testing.T) {
 	tr := &v1beta1.TaskRun{}
 	now := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
 	tenMinuteLater := now.Add(10 * time.Minute)
@@ -180,7 +180,7 @@ func TestModifyTaskRunStatusTaskStartTime(t *testing.T) {
 		tr.Status = status
 		modifyTaskRunStatusStepStartTime(tr)
 		if d := cmp.Diff(tr.Status, status); d != "" {
-			t.Errorf("status should not change as there is only one running status, changed: %s", d)
+			t.Errorf("status should not change since this is the first step in running status, changed: %s", d)
 		}
 	})
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
